### PR TITLE
Support 11.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json" ~> 10.0.0
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" ~> 10.0.0
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 10.0.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json" ~> 11.0.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" ~> 11.0.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 11.0.0

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "SwiftyRemoteConfig",
     platforms: [
-        .iOS(.v11),
-        .macOS(.v10_13),
-        .tvOS(.v12),
-        .watchOS(.v6),
+        .iOS(.v12),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v7),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/firebase/firebase-ios-sdk.git",
-            .upToNextMajor(from: "10.29.0")
+            .upToNextMajor(from: "11.0.0")
         ),
     ],
     targets: [

--- a/Sources/SwiftyRemoteConfig/RemoteConfigBridge.swift
+++ b/Sources/SwiftyRemoteConfig/RemoteConfigBridge.swift
@@ -46,7 +46,7 @@ public struct RemoteConfigStringBridge: RemoteConfigBridge {
     public func get(key: String, remoteConfig: RemoteConfig) -> String? {
         let configValue = remoteConfig.configValue(forKey: key)
         
-        if configValue.stringValue?.isEmpty == true || configValue.stringValue.isNil {
+        if configValue.stringValue.isEmpty == true {
             return nil
         }
         
@@ -64,7 +64,7 @@ public struct RemoteConfigIntBridge: RemoteConfigBridge {
     public func get(key: String, remoteConfig: RemoteConfig) -> Int? {
         let configValue = remoteConfig.configValue(forKey: key)
         
-        if configValue.stringValue?.isEmpty == true || configValue.stringValue.isNil {
+        if configValue.stringValue.isEmpty == true {
             return nil
         }
         
@@ -82,7 +82,7 @@ public struct RemoteConfigDoubleBridge: RemoteConfigBridge {
     public func get(key: String, remoteConfig: RemoteConfig) -> Double? {
         let configValue = remoteConfig.configValue(forKey: key)
         
-        if configValue.stringValue?.isEmpty == true || configValue.stringValue.isNil {
+        if configValue.stringValue.isEmpty == true {
             return nil
         }
         
@@ -100,7 +100,7 @@ public struct RemoteConfigBoolBridge: RemoteConfigBridge {
     public func get(key: String, remoteConfig: RemoteConfig) -> Bool? {
         let configValue = remoteConfig.configValue(forKey: key)
         
-        if configValue.stringValue?.isEmpty == true || configValue.stringValue.isNil {
+        if configValue.stringValue.isEmpty == true {
             return nil
         }
         
@@ -133,12 +133,12 @@ public struct RemoteConfigUrlBridge: RemoteConfigBridge {
     }
 
     public func deserialize(_ object: RemoteConfigValue) -> URL? {
-        if let stringValue = object.stringValue, stringValue.isEmpty == false {
-            if let url = URL(string: stringValue) {
+        if object.stringValue.isEmpty == false {
+            if let url = URL(string: object.stringValue) {
                 return url
             }
 
-            let path = (stringValue as NSString).expandingTildeInPath
+            let path = (object.stringValue as NSString).expandingTildeInPath
             return URL(fileURLWithPath: path)
         }
 

--- a/SwiftyRemoteConfig.podspec
+++ b/SwiftyRemoteConfig.podspec
@@ -12,16 +12,16 @@ Pod::Spec.new do |spec|
   spec.authors            = { "Fumito Ito" => "weathercook@gmail.com" }
   spec.social_media_url   = "https://twitter.com/fumito_ito"
 
-  spec.ios.deployment_target = "11.0"
-  spec.osx.deployment_target = "10.12"
-  spec.tvos.deployment_target = "12.0"
-  spec.watchos.deployment_target = "6.0"
+  spec.ios.deployment_target = "12.0"
+  spec.osx.deployment_target = "10.15"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "7.0"
   spec.source       = { :git => "https://github.com/fumito-ito/SwiftyRemoteConfig.git", :tag => "#{spec.version}" }
   spec.source_files  = "Sources", "Sources/**/*.swift"
   spec.requires_arc = true
   spec.swift_versions = "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"
 
   spec.static_framework = true
-  spec.dependency "FirebaseRemoteConfig", "~> 10.0.0"
+  spec.dependency "FirebaseRemoteConfig", "~> 11.0.0"
 
 end

--- a/Tests/SwiftyRemoteConfigTests/Helpers/TestHelper.swift
+++ b/Tests/SwiftyRemoteConfigTests/Helpers/TestHelper.swift
@@ -79,7 +79,8 @@ struct FrogCustomSerializable: RemoteConfigSerializable, Equatable {
 
 final class RemoteConfigFrogBridge: RemoteConfigBridge {
     func get(key: String, remoteConfig: RemoteConfig) -> FrogCustomSerializable? {
-        guard let name = remoteConfig.configValue(forKey: key).stringValue, name.isEmpty == false else {
+        let name = remoteConfig.configValue(forKey: key).stringValue
+        guard name.isEmpty == false else {
             return nil
         }
         
@@ -87,11 +88,11 @@ final class RemoteConfigFrogBridge: RemoteConfigBridge {
     }
     
     func deserialize(_ object: RemoteConfigValue) -> FrogCustomSerializable? {
-        guard let name = object.stringValue, name.isEmpty == false else {
+        guard object.stringValue.isEmpty == false else {
             return nil
         }
 
-        return FrogCustomSerializable.init(name: name)
+        return FrogCustomSerializable.init(name: object.stringValue)
     }
 }
 


### PR DESCRIPTION
## WHAT

- Bump deployment target for each OSs.
- Fix API changes. `stringValue` is not optional above 11.0.0